### PR TITLE
refactor(circuit): opt Pow5()

### DIFF
--- a/src/lib/rescue.circom
+++ b/src/lib/rescue.circom
@@ -2,12 +2,10 @@ include "./rescue_constants.circom";
 
 template Pow5() {
     signal input in;
+    signal tmp;
     signal output out;
-    signal in2;
-    signal in4;
-    in2 <== in*in;
-    in4 <== in2*in2;
-    out <== in4*in;
+    tmp <-- in**5;
+    out <== tmp;
 }
 
 template InvPow5() {


### PR DESCRIPTION
with plonk_release and without lagrange 

before:
```
 =========== benchmark results: ================= 

+ head data/transfer/plonkit.time data/transfer/zkutil.time
==> data/transfer/plonkit.time <==
+ plonkit prove -m '/home/chris/gitfiles/Fluidex/circuits/tools/benchmark/keys/plonk/setup_2^20.key' --circuit circuit.r1cs.json --witness witness.json --proof proof.bin

real    0m5.719s
user    0m32.176s
sys     0m0.350s

==> data/transfer/zkutil.time <==
+ zkutil prove

real    0m0.745s
user    0m3.467s
sys     0m0.081s
```

after
```
 =========== benchmark results: ================= 

+ head data/transfer/plonkit.time data/transfer/zkutil.time
==> data/transfer/plonkit.time <==
+ plonkit prove -m '/home/chris/gitfiles/Fluidex/circuits/tools/benchmark/keys/plonk/setup_2^20.key' --circuit circuit.r1cs.json --witness witness.json --proof proof.bin

real    0m1.559s
user    0m7.217s
sys     0m0.207s

==> data/transfer/zkutil.time <==
+ zkutil prove

real    0m0.168s
user    0m0.775s
sys     0m0.000s
```