### PR TITLE
Update integration test case

### DIFF
--- a/test/integration_test_cases.ts
+++ b/test/integration_test_cases.ts
@@ -26,9 +26,11 @@ function fromPubkey(pbk: string): { sign: bigint; ay: bigint } {
 
 const accountID1 = BigInt(1);
 const accountID2 = BigInt(2);
+const accountID3 = BigInt(3);
 
 const testPubkey1 = '5d182c51bcfe99583d7075a7a0c10d96bef82b8a059c4bf8c5f6e7124cf2bba3';
 const testPubkey2 = 'e9b54eb2dbf0a14faafd109ea2a6a292b78276c8381f8ef984dddefeafb2deaf';
+const testPubkey3 = '5d182c51bcfe99583d7075a7a0c10d96bef82b8a059c4bf8c5f6e7124cf2bba3';
 
 //fake "deposit to new" like what has been done in the rs rollup-manager
 state.DepositToNew({
@@ -41,7 +43,6 @@ state.DepositToNew({
 
 state.DepositToNew({
   accountID: accountID2,
-  //in 'fake deposit' we use tokeID as 0
   tokenID: BigInt(0),
   amount: BigInt(0),
   ...fromPubkey(testPubkey2),
@@ -61,7 +62,21 @@ state.Withdraw({
     'ce6e16056da007b3d7274db0ef3f546a101bd99be4137dfe97340b8f2481caac3a7af82bef9d00c226227280413de24714acd2458ba369d052ea43e0cd063601',
 });
 
+state.DepositToNew({
+  accountID: accountID3,
+  tokenID: BigInt(0),
+  amount: BigInt(0),
+  ...fromPubkey(testPubkey3),
+});
+
+state.DepositToOld({
+  accountID: accountID3,
+  tokenID: BigInt(0), //in integration test we specified "ETH" which has a hardcoded id as 0
+  amount: BigInt(30_000),
+});
+
 let blocks = state.forgeAllL2Blocks();
 console.log('the merkle root should be asserted as following:');
 console.log('block 0:', '0x' + blocks[0].newRoot.toString(16));
 console.log('block 1:', '0x' + blocks[1].newRoot.toString(16));
+console.log('block 2:', '0x' + blocks[2].newRoot.toString(16));


### PR DESCRIPTION
Update the integration test case according to rollup PR https://github.com/fluidex/rollup-state-manager/pull/203

1. I just harcoded the `signature` of Withdraw. It seems that it could be calculated by `fluidex.js` (also for test file `get_l2_block_by_id.ts` of `rollup_state_manager`).
2. Output `newroot` of the second block has a little different with the one of rollup (a odd `0` after `0x`).
```
// this integration test
0xcf9708094c494c668f6943ab4cfba04882d2b25303244e6ae6f14931a0c008c
// rollup
0x0cf9708094c494c668f6943ab4cfba04882d2b25303244e6ae6f14931a0c008c
```

